### PR TITLE
Expanded Delete functionality

### DIFF
--- a/src/main/kotlin/com/it1shka/capture/database/DocumentUserAccessRepository.kt
+++ b/src/main/kotlin/com/it1shka/capture/database/DocumentUserAccessRepository.kt
@@ -12,4 +12,5 @@ interface DocumentUserAccessRepository : ReactiveCrudRepository<DocumentUserAcce
   fun findByDocumentId(documentId: UUID): Flux<DocumentUserAccess>
   fun findByUserIdAndDocumentId(userId: String, documentId: UUID): Mono<DocumentUserAccess>
   fun deleteByDocumentId(documentId: UUID): Mono<Unit>
+  fun deleteByUserIdAndDocumentId(userId: String, documentId: UUID): Mono<Unit>
 }

--- a/src/main/kotlin/com/it1shka/capture/services/DocumentService.kt
+++ b/src/main/kotlin/com/it1shka/capture/services/DocumentService.kt
@@ -96,7 +96,9 @@ class DocumentService(
       .flatMap { document ->
         documentUserAccessRepository.findByUserIdAndDocumentId(userId, documentId)
           .filter { access -> access.role.canDelete() }
-          .switchIfEmpty(Mono.error(SecurityException("User doesn't have permission")))
+          .switchIfEmpty(
+            documentUserAccessRepository.deleteByUserIdAndDocumentId(userId, documentId)
+          )
           .then(
             documentUserAccessRepository.deleteByDocumentId(documentId)
              .then(documentRepository.delete(document))


### PR DESCRIPTION
Added logic for deleting documents for non Author users - they simply delete their access to the document instead of the document and access of all users